### PR TITLE
Handling a ’ character in device name

### DIFF
--- a/JBDeviceOwner/JBDeviceOwner.m
+++ b/JBDeviceOwner/JBDeviceOwner.m
@@ -44,7 +44,8 @@
     self.device = aDevice;
     NSMutableString *deviceName = [NSMutableString stringWithString:self.device.name];
 
-    NSArray *stringsToStrip = [NSArray arrayWithObjects:@"'s",
+    NSArray *stringsToStrip = [NSArray arrayWithObjects:@"’s",
+                                                        @"'s",
                                                         @"ipad",
                                                         @"iphone",
                                                         @"ipod touch", nil];


### PR DESCRIPTION
When I tried out the library on my iPhone 4s, it failed as my device name had a ’ character rather than ' character to separate the name from the 's'.
