### PR TITLE
check for nil reference addressBook

### DIFF
--- a/JBDeviceOwner/JBDeviceOwner.m
+++ b/JBDeviceOwner/JBDeviceOwner.m
@@ -107,7 +107,9 @@
     CFRelease(phoneMultiValue);
   }
 
-  CFRelease(addressBook);
+  if( addressBook != nil ){
+    CFRelease(addressBook);
+  }
 }
 
 @end


### PR DESCRIPTION
@jakeboxer please take a look!

I will admit, I was unable to use the static framework lib since it did not support all the CPU platforms required by my project, and likely I have ARC enabled in my project, but I don't think either of those is really the issue here.  I think there is another thing going on here, where the addressBook is nil in the circumstance defined in https://github.com/jakeboxer/JBDeviceOwner/issues/10 at least in in newer IOS versions.

Perhaps when ARC is not enabled then this would not be an issue?  I have not tested that, but I am confident this fixes the issue as I have tested and confirmed in my project.

Thanks for creating this library!